### PR TITLE
Define PoC milestone and core Plan-Revise-Build workflow

### DIFF
--- a/milestones/PoC.md
+++ b/milestones/PoC.md
@@ -1,11 +1,11 @@
-# MVP Milestone
+# PoC Milestone
 
 ## Problem
 
 Analysts need a first end-to-end product that can generate actionable plans and iteratively improve outputs from human feedback.  
 The plan is expressed in markdown by the orchestration system and converted to HTML in the UI for review and commenting.
 
-This MVP also validates a market gap: business teams need agentic LLM workflows that are usable by average office workers who are not technical, are not interested in code as a deliverable, and do not use developer tools such as Cursor.  
+This PoC also validates a market gap: business teams need agentic LLM workflows that are usable by average office workers who are not technical, are not interested in code as a deliverable, and do not use developer tools such as Cursor.  
 The current gap is the lack of a business-native experience that preserves powerful LLM reasoning while presenting work in familiar document-review patterns (read, comment, revise) instead of coding workflows.
 
 ## Core Workflow Model (Plan -> Revise -> Build)
@@ -39,7 +39,7 @@ The system follows a Plan -> Revise -> Build workflow for back-office tasks.
      - The analytical direction is correct
      - Organizational standards are respected
 
-3. Build *(for context only, outside MVP scope)*
+3. Build *(for context only, outside PoC scope)*
    - Once approved, agents execute the full plan by:
      - Retrieving data
      - Running analysis
@@ -57,7 +57,7 @@ flowchart TD
     D[4. Analyst comments on plan and requests revisions]
     E[5. System addresses feedback and presents updated plan]
     F{6. Analyst approves the plan?}
-    G[7. Out of MVP scope: agent executes plan and saves deliverable]
+    G[7. Out of PoC scope: agent executes plan and saves deliverable]
 
     A --> B --> C --> D --> E --> F
     F -- No, needs more changes --> D
@@ -72,7 +72,7 @@ flowchart TD
 - Build a Python backend that receives comments plus document location metadata and feeds both back into the LLM workflow.
 - Use ChatGPT via API as the LLM provider for planning and feedback-driven updates.
 - Return updated outputs to the UI after comment ingestion and LLM processing.
-- Keep the Build stage explicitly out of MVP scope; include it only as future workflow context.
+- Keep the Build stage explicitly out of PoC scope; include it only as future workflow context.
 
 ## Work Breakdown Structure
 
@@ -90,5 +90,5 @@ flowchart TD
    2. Handle retries, response validation, and error states.
 5. End-to-end validation
    1. Verify Plan -> Revise cycle: plan generation -> UI rendering -> comment submission -> revised plan output.
-6. Future scope placeholder (non-MVP)
+6. Future scope placeholder (non-PoC)
    1. Document Build-stage execution requirements for a later milestone.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- rename milestone document from `milestones/MVP.md` to `milestones/PoC.md`
- update milestone naming and scope language from MVP to PoC
- preserve the defined workflow and requirements:
  - Plan -> Revise -> Build model
  - HTML comment-based revision on markdown-rendered plans
  - location-aware feedback injection into LLM prompts
  - Build execution kept out of current scope

## Testing
- not applicable (documentation-only changes)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60765681-f3e6-4d91-b292-6f93ea77966a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60765681-f3e6-4d91-b292-6f93ea77966a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

