### PR TITLE
Reviewed LLM response metadata behavior to avoid flashing raw JSON

### DIFF
--- a/.cursor/rules/feature-planning.mdc
+++ b/.cursor/rules/feature-planning.mdc
@@ -78,6 +78,17 @@ Each sequential action that will be taken to achieve the goal:
 
 ---
 
+### TODOs and codebase markers
+
+When creating an implementation plan, **check for existing TODO-style debt** in the areas you intend to change:
+
+- Search relevant paths for `TODO`, `FIXME`, `XXX`, and `HACK` comments tied to the same feature, subsystem, or failure mode; fold them into **Steps**, **Guardrails**, or an explicit **Follow-ups / deferred work** note so they are not ignored when the plan is executed.
+- If the plan intentionally defers work (including observability, migrations, or cleanup), say so in the plan rather than leaving only a code comment or implicit debt.
+
+**Won't do:** Ignoring nearby TODOs that the new work will touch; adding a vague "address tech debt" step without naming the marker or file.
+
+---
+
 ### Guardrails
 
 A list of constraints and checks to validate the solution:

--- a/plans/2026-03-19-agentic-orchestrator-poc.md
+++ b/plans/2026-03-19-agentic-orchestrator-poc.md
@@ -423,3 +423,34 @@ sequenceDiagram
   Orchestrator->>Orchestrator: split markdown and metadata, save session
   Orchestrator->>Client: SSE final
 ```
+
+---
+
+## Addendum — Split streamed answer and hidden JSON metadata (2026-03-21)
+
+After response streaming landed, the assistant generation path still appended a **trailing fenced JSON metadata block** to the same streamed string. Until that block finished, the UI could show **partial JSON** (and text adjacent to it), which was poor UX.
+
+**Change:** generation is now **two LLM calls per turn**:
+
+1. **Call 1 (streamed):** User-facing markdown only. The follow-up, plan-generation, and plan-refinement prompts instruct the model **not** to output JSON or metadata fences. Tokens are forwarded to the client as SSE **`chunk`** events as before.
+2. **Call 2 (hidden, non-streamed):** A separate prompt (`response-metadata.md`) receives session context plus the full markdown from call 1 and returns **JSON only** (`response_format: json_object`), shaped as `PromptResponseMetadata` (`confidence`, `next_action`, `missing_information`). The OpenAI client builds metadata from this response; failures fall back to safe defaults and are logged. A **`response-metadata`** step artifact records the parsed metadata for inspectability.
+
+The **HTTP/SSE contract is unchanged:** `final` still includes `assistant_message` (clean markdown) and `response_metadata`. No frontend change was required for this split.
+
+### Sequence diagram (two-call generation)
+
+```mermaid
+sequenceDiagram
+  participant Engine
+  participant LLM1
+  participant LLM2
+  participant UI
+  Engine->>LLM1: stream generation prompt
+  loop deltas
+    LLM1-->>Engine: markdown token
+    Engine-->>UI: SSE chunk
+  end
+  Engine->>LLM2: metadata prompt plus full markdown answer
+  LLM2-->>Engine: JSON object only
+  Engine-->>UI: SSE final with clean assistant_message and response_metadata
+```

--- a/services/orchestration-server/backend/integrations/openai_client.py
+++ b/services/orchestration-server/backend/integrations/openai_client.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
 import json
-import re
+import logging
 from collections.abc import Iterator
 from typing import Any, Protocol
 
+from pydantic import ValidationError
+
 from backend.config import Settings
-from backend.orchestrator.models import (
-    GeneratedResponse,
-    NextAction,
-    PromptResponseMetadata,
-    StateCheck,
-)
+from backend.orchestrator.models import NextAction, PromptResponseMetadata, StateCheck
 from backend.orchestrator.prompts import BuiltPrompt
 
 try:
     from openai import OpenAI
 except ImportError:  # pragma: no cover - exercised only when dependency is absent
     OpenAI = None
+
+logger = logging.getLogger(__name__)
 
 
 class LLMClient(Protocol):
@@ -29,7 +28,9 @@ class LLMClient(Protocol):
 
     def refine_plan_stream(self, prompt: BuiltPrompt) -> Iterator[str]: ...
 
-    def finalize_generation(self, accumulated: str, prompt: BuiltPrompt) -> GeneratedResponse: ...
+    def extract_generation_metadata(
+        self, metadata_prompt: BuiltPrompt, generation_prompt: BuiltPrompt
+    ) -> PromptResponseMetadata: ...
 
 
 class OpenAIOrchestratorClient:
@@ -53,17 +54,33 @@ class OpenAIOrchestratorClient:
     def refine_plan_stream(self, prompt: BuiltPrompt) -> Iterator[str]:
         yield from self._stream_text_prompt(prompt, self.settings.openai_generation_model)
 
-    def finalize_generation(self, accumulated: str, prompt: BuiltPrompt) -> GeneratedResponse:
-        content, raw_metadata = _split_markdown_and_metadata(accumulated)
-        metadata = PromptResponseMetadata(
-            prompt_name=prompt.name,
-            prompt_path=str(prompt.path),
-            confidence=float(raw_metadata.get("confidence", 0.0)),
-            next_action=NextAction(raw_metadata.get("next_action", NextAction.WAIT_FOR_USER.value)),
-            missing_information=list(raw_metadata.get("missing_information", [])),
-            raw_metadata=raw_metadata,
-        )
-        return GeneratedResponse(content=content, metadata=metadata)
+    def extract_generation_metadata(
+        self, metadata_prompt: BuiltPrompt, generation_prompt: BuiltPrompt
+    ) -> PromptResponseMetadata:
+        # Small JSON task; same model as state check unless we add a dedicated setting later.
+        try:
+            raw = self._run_json_prompt(metadata_prompt, self.settings.openai_state_check_model)
+            return PromptResponseMetadata(
+                prompt_name=generation_prompt.name,
+                prompt_path=str(generation_prompt.path),
+                confidence=float(raw.get("confidence", 0.0)),
+                next_action=NextAction(raw.get("next_action", NextAction.WAIT_FOR_USER.value)),
+                missing_information=list(raw.get("missing_information", [])),
+                raw_metadata=raw,
+            )
+        except (json.JSONDecodeError, ValidationError, ValueError, TypeError) as exc:
+            # TODO(observability): Treat metadata extraction failures as a first-class signal:
+            # emit metrics, a trace span, or structured events (e.g. metadata_extraction_failed)
+            # so operators can detect this path without relying on generic error logs alone.
+            logger.warning("Response metadata extraction failed: %s", exc, exc_info=True)
+            return PromptResponseMetadata(
+                prompt_name=generation_prompt.name,
+                prompt_path=str(generation_prompt.path),
+                confidence=0.0,
+                next_action=NextAction.WAIT_FOR_USER,
+                missing_information=["metadata extraction failed"],
+                raw_metadata={"error": str(exc)},
+            )
 
     def _run_json_prompt(self, prompt: BuiltPrompt, model: str) -> dict[str, Any]:
         if not self._client:
@@ -97,14 +114,3 @@ class OpenAIOrchestratorClient:
             delta = choice.delta.content if choice.delta else None
             if delta:
                 yield delta
-
-
-def _split_markdown_and_metadata(text: str) -> tuple[str, dict[str, Any]]:
-    matches = list(re.finditer(r"```json\s*(\{.*?\})\s*```", text, flags=re.DOTALL))
-    if not matches:
-        return text.strip(), {}
-
-    last_match = matches[-1]
-    markdown = text[: last_match.start()].strip()
-    metadata = json.loads(last_match.group(1))
-    return markdown, metadata

--- a/services/orchestration-server/backend/orchestrator/engine.py
+++ b/services/orchestration-server/backend/orchestrator/engine.py
@@ -142,8 +142,24 @@ class OrchestratorEngine:
             parts.append(delta)
             yield ("chunk", {"content": delta})
 
-        full_text = "".join(parts)
-        response = self.llm_client.finalize_generation(full_text, prompt)
+        assistant_markdown = "".join(parts).strip()
+        metadata_prompt = self.prompt_manager.build_response_metadata_prompt(
+            session,
+            latest_user_message,
+            assistant_markdown,
+            assistant_kind,
+        )
+        metadata = self.llm_client.extract_generation_metadata(metadata_prompt, prompt)
+        self.store.append_step_artifact(
+            session,
+            "response-metadata",
+            {
+                "prompt_name": metadata_prompt.name,
+                "prompt_path": str(metadata_prompt.path),
+                "metadata": metadata.model_dump(mode="json"),
+            },
+        )
+        response = GeneratedResponse(content=assistant_markdown, metadata=metadata)
 
         assistant_turn = TurnRecord(
             role=TurnRole.ASSISTANT,

--- a/services/orchestration-server/backend/orchestrator/prompts.py
+++ b/services/orchestration-server/backend/orchestrator/prompts.py
@@ -47,6 +47,33 @@ class PromptManager:
     ) -> BuiltPrompt:
         return self._build("plan-refinement.md", session, latest_message, "Plan Refinement")
 
+    def build_response_metadata_prompt(
+        self,
+        session: SessionState,
+        latest_user_message: str,
+        assistant_markdown: str,
+        assistant_kind: str,
+    ) -> BuiltPrompt:
+        path = self.prompt_root / "response-metadata.md"
+        system_prompt = path.read_text(encoding="utf-8")
+        user_prompt = "\n".join(
+            [
+                self._render_context(session, latest_user_message),
+                "",
+                "# Assistant message kind",
+                assistant_kind,
+                "",
+                "# Assistant markdown answer",
+                assistant_markdown,
+            ]
+        )
+        return BuiltPrompt(
+            name="Response Metadata",
+            path=path,
+            system_prompt=system_prompt,
+            user_prompt=user_prompt,
+        )
+
     def _build(
         self,
         filename: str,

--- a/services/orchestration-server/prompts/orchestrator/plan-generation.md
+++ b/services/orchestration-server/prompts/orchestrator/plan-generation.md
@@ -29,17 +29,7 @@ The content should match the format expectations described in `.cursor/rules/fea
 
 ## Output Format
 
-Return the full plan in markdown followed by a JSON metadata block.
-
-Metadata block:
-
-```json
-{
-  "confidence": 0.86,
-  "next_action": "wait_for_user",
-  "missing_information": []
-}
-```
+Return the **full plan in markdown only**. Do **not** append JSON, metadata, or any fenced code block for machine-readable data.
 
 ## Style Rules
 

--- a/services/orchestration-server/prompts/orchestrator/plan-refinement.md
+++ b/services/orchestration-server/prompts/orchestrator/plan-refinement.md
@@ -20,7 +20,7 @@ You are an agentic planning assistant refining an existing plan. Your job is to 
 - Improve the plan based on the feedback.
 - Preserve sections or details that remain valid.
 - Remove or rewrite only what is no longer aligned with the feedback.
-- If the feedback suggests missing information or uncertainty, reflect that in the metadata confidence value.
+- If the feedback suggests missing information or uncertainty, reflect that in the revised plan text (tone, caveats, open questions).
 - Keep the refined plan in the same markdown structure:
   - `## Goal`
   - `## Preconditions`
@@ -30,23 +30,11 @@ You are an agentic planning assistant refining an existing plan. Your job is to 
 
 ## Output Format
 
-Return the revised plan in markdown followed by a JSON metadata block.
-
-Metadata block:
-
-```json
-{
-  "confidence": 0.74,
-  "next_action": "wait_for_user",
-  "missing_information": [
-    "approval criteria for final plan"
-  ]
-}
-```
+Return the **revised plan in markdown only**. Do **not** append JSON, metadata, or any fenced code block for machine-readable data.
 
 ## Style Rules
 
 - Make the plan more useful, not just different.
 - Incorporate explicit analyst feedback.
 - Keep the writing concise and implementation-oriented.
-- If the feedback is ambiguous, do not invent certainty in the metadata.
+- If the feedback is ambiguous, do not invent certainty in the revised plan.

--- a/services/orchestration-server/prompts/orchestrator/problem-understanding.md
+++ b/services/orchestration-server/prompts/orchestrator/problem-understanding.md
@@ -26,26 +26,12 @@ Do not generate a full plan in this step.
 
 ## Output Format
 
-Return markdown for the analyst followed by a JSON metadata block.
+Return **markdown only** for the analyst. Do **not** append JSON, metadata, or any fenced code block for machine-readable data.
 
-Markdown section:
+The markdown should:
 
 - briefly summarize your current understanding
 - ask the smallest useful set of follow-up questions
-
-Metadata block:
-
-```json
-{
-  "confidence": 0.58,
-  "next_action": "ask_follow_up",
-  "missing_information": [
-    "target audience",
-    "expected deliverable",
-    "decision criteria"
-  ]
-}
-```
 
 ## Style Rules
 

--- a/services/orchestration-server/prompts/orchestrator/response-metadata.md
+++ b/services/orchestration-server/prompts/orchestrator/response-metadata.md
@@ -1,0 +1,27 @@
+# Response Metadata (hidden step)
+
+## Purpose
+
+You are not shown to the analyst. Given the session context and the assistant’s markdown answer from the previous step, infer structured **next-step metadata** for the orchestrator.
+
+## Role
+
+Read the analyst-facing markdown answer (and the context blocks in the user message). Output a single JSON object only—no markdown, no prose, no code fences.
+
+## Required JSON shape
+
+Keys (exact names):
+
+- `confidence` — number from 0.0 to 1.0 reflecting how well the answer supports a clear next orchestrator action.
+- `next_action` — one of: `ask_follow_up`, `create_plan`, `refine_plan`, `wait_for_user`.
+- `missing_information` — array of short strings listing gaps that still block a confident next step (empty array if none).
+
+## Semantics
+
+- Use `wait_for_user` when the assistant has delivered a plan or follow-up and the system should pause for analyst input.
+- Use `ask_follow_up` when more clarification is still needed before planning or refining.
+- Align `missing_information` with concrete gaps implied by the assistant answer and the conversation.
+
+## Output
+
+Emit **only** one JSON object. No other text.

--- a/services/orchestration-server/tests/conftest.py
+++ b/services/orchestration-server/tests/conftest.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable, Iterator
 import pytest
 
 from backend.config import SERVICE_ROOT, Settings
-from backend.orchestrator.models import GeneratedResponse, StateCheck
+from backend.orchestrator.models import GeneratedResponse, PromptResponseMetadata, StateCheck
 from backend.orchestrator.prompts import BuiltPrompt
 
 
@@ -28,7 +28,9 @@ class FakeLLMClient:
         self.follow_up_prompts = []
         self.plan_prompts = []
         self.refinement_prompts = []
+        self.metadata_prompts: list[BuiltPrompt] = []
         self._stream_pending: GeneratedResponse | None = None
+        self._stream_accumulated = ""
 
     def run_state_check(self, prompt):
         self.state_check_prompts.append(prompt)
@@ -42,26 +44,44 @@ class FakeLLMClient:
     def generate_follow_up_questions_stream(self, prompt) -> Iterator[str]:
         self.follow_up_prompts.append(prompt)
         self._stream_pending = self.follow_up_responses.pop(0)
-        yield from self._yield_content_chunks(self._stream_pending.content)
+        self._stream_accumulated = ""
+        for chunk in self._yield_content_chunks(self._stream_pending.content):
+            self._stream_accumulated += chunk
+            yield chunk
 
     def generate_plan_stream(self, prompt) -> Iterator[str]:
         self.plan_prompts.append(prompt)
         self._stream_pending = self.plan_responses.pop(0)
-        yield from self._yield_content_chunks(self._stream_pending.content)
+        self._stream_accumulated = ""
+        for chunk in self._yield_content_chunks(self._stream_pending.content):
+            self._stream_accumulated += chunk
+            yield chunk
 
     def refine_plan_stream(self, prompt) -> Iterator[str]:
         self.refinement_prompts.append(prompt)
         self._stream_pending = self.refinement_responses.pop(0)
-        yield from self._yield_content_chunks(self._stream_pending.content)
+        self._stream_accumulated = ""
+        for chunk in self._yield_content_chunks(self._stream_pending.content):
+            self._stream_accumulated += chunk
+            yield chunk
 
-    def finalize_generation(self, accumulated: str, prompt: BuiltPrompt) -> GeneratedResponse:
+    def extract_generation_metadata(
+        self, metadata_prompt: BuiltPrompt, generation_prompt: BuiltPrompt
+    ) -> PromptResponseMetadata:
         pending = self._stream_pending
         self._stream_pending = None
         if pending is None:
-            raise RuntimeError("finalize_generation called without a preceding stream")
-        if accumulated != pending.content:
+            raise RuntimeError("extract_generation_metadata called without a preceding stream")
+        if self._stream_accumulated != pending.content:
             raise AssertionError("Streamed text does not match pending generated response")
-        return pending
+        self._stream_accumulated = ""
+        self.metadata_prompts.append(metadata_prompt)
+        return pending.metadata.model_copy(
+            update={
+                "prompt_name": generation_prompt.name,
+                "prompt_path": str(generation_prompt.path),
+            }
+        )
 
 
 @pytest.fixture

--- a/services/orchestration-server/tests/test_orchestrator_api.py
+++ b/services/orchestration-server/tests/test_orchestrator_api.py
@@ -111,6 +111,7 @@ def test_api_streams_session_and_persists_final_state(test_settings):
     session_id = first_events["session"][0]["session_id"]
     assert first_events["chunk"][0]["content"].startswith("Please share")
     assert first_events["final"][0]["state_check"]["next_action"] == "ask_follow_up"
+    assert llm_client.metadata_prompts[0].path.name == "response-metadata.md"
 
     with client.stream(
         "POST",
@@ -125,6 +126,7 @@ def test_api_streams_session_and_persists_final_state(test_settings):
     second_events = _parse_sse(second_stream)
     assert second_events["final"][0]["assistant_kind"] == "plan"
     assert second_events["final"][0]["current_plan_markdown"].startswith("## Goal")
+    assert llm_client.metadata_prompts[1].path.name == "response-metadata.md"
 
     session_response = client.get(f"/orchestrator/sessions/{session_id}")
     assert session_response.status_code == 200

--- a/services/orchestration-server/tests/test_orchestrator_engine.py
+++ b/services/orchestration-server/tests/test_orchestrator_engine.py
@@ -69,6 +69,7 @@ def test_engine_asks_follow_up_when_confidence_is_below_threshold(test_settings)
     assert result.assistant_turn.kind == "follow_up_questions"
     assert "below the configured threshold" in result.state_check.reason
     assert llm_client.follow_up_prompts[0].path.name == "problem-understanding.md"
+    assert llm_client.metadata_prompts[0].path.name == "response-metadata.md"
     assert not llm_client.plan_prompts
 
 
@@ -137,6 +138,7 @@ def test_engine_generates_and_refines_plan_with_latest_plan_in_context(test_sett
 
     first_turn = engine.start_session("Build a planning workflow.")
     assert first_turn.assistant_turn.kind == "follow_up_questions"
+    assert llm_client.metadata_prompts[0].path.name == "response-metadata.md"
     session_id = first_turn.session.session_id
 
     second_turn = engine.advance_session(
@@ -146,6 +148,7 @@ def test_engine_generates_and_refines_plan_with_latest_plan_in_context(test_sett
     assert second_turn.assistant_turn.kind == "plan"
     assert second_turn.session.current_plan_markdown.startswith("## Goal")
     assert llm_client.plan_prompts[0].path.name == "plan-generation.md"
+    assert llm_client.metadata_prompts[1].path.name == "response-metadata.md"
 
     third_turn = engine.advance_session(
         session_id,
@@ -156,3 +159,4 @@ def test_engine_generates_and_refines_plan_with_latest_plan_in_context(test_sett
     assert len(third_turn.session.plan_versions) == 2
     assert llm_client.refinement_prompts[0].path.name == "plan-refinement.md"
     assert "Create the first plan." in llm_client.refinement_prompts[0].user_prompt
+    assert llm_client.metadata_prompts[2].path.name == "response-metadata.md"


### PR DESCRIPTION
# Summary

- Introduced a new extract_generation_metadata method in the LLM client to handle structured metadata extraction from assistant responses.
- Updated the orchestrator engine to utilize the new metadata extraction method, improving the handling of response metadata.
- Refactored prompt generation to ensure that responses are returned in markdown format only, removing any appended JSON or metadata blocks.
- Added a new response-metadata.md prompt to define the structure and purpose of the metadata extraction process.
- Updated tests to verify the integration of metadata prompts and ensure correct functionality across the orchestration serve
- Updated plan documentation with changes